### PR TITLE
logformat to log-format

### DIFF
--- a/Modules/II-k6-Foundations/02-The-k6-CLI.md
+++ b/Modules/II-k6-Foundations/02-The-k6-CLI.md
@@ -57,7 +57,7 @@ Flags:
   -c, --config string       JSON config file (default "/Users/nic/Library/Application Support/loadimpact/k6/config.json")
   -h, --help                help for k6
       --log-output string   change the output for k6 logs, possible values are stderr,stdout,none,loki[=host:port] (default "stderr")
-      --log-format string    log output format
+      --log-format string   log output format
       --no-color            disable colored output
   -q, --quiet               disable progress updates
   -v, --verbose             enable verbose logging

--- a/Modules/II-k6-Foundations/02-The-k6-CLI.md
+++ b/Modules/II-k6-Foundations/02-The-k6-CLI.md
@@ -57,7 +57,7 @@ Flags:
   -c, --config string       JSON config file (default "/Users/nic/Library/Application Support/loadimpact/k6/config.json")
   -h, --help                help for k6
       --log-output string   change the output for k6 logs, possible values are stderr,stdout,none,loki[=host:port] (default "stderr")
-      --logformat string    log output format
+      --log-format string    log output format
       --no-color            disable colored output
   -q, --quiet               disable progress updates
   -v, --verbose             enable verbose logging

--- a/slides/05-the-k6-cli/slides.md
+++ b/slides/05-the-k6-cli/slides.md
@@ -65,7 +65,7 @@ Flags:
   -c, --config string       JSON config file (default "/Users/nic/Library/Application Support/loadimpact/k6/config.json")
   -h, --help                help for k6
       --log-output string   change the output for k6 logs, possible values are stderr,stdout,none,loki[=host:port] (default "stderr")
-      --log-format string    log output format
+      --log-format string   log output format
       --no-color            disable colored output
   -q, --quiet               disable progress updates
   -v, --verbose             enable verbose logging

--- a/slides/05-the-k6-cli/slides.md
+++ b/slides/05-the-k6-cli/slides.md
@@ -65,7 +65,7 @@ Flags:
   -c, --config string       JSON config file (default "/Users/nic/Library/Application Support/loadimpact/k6/config.json")
   -h, --help                help for k6
       --log-output string   change the output for k6 logs, possible values are stderr,stdout,none,loki[=host:port] (default "stderr")
-      --logformat string    log output format
+      --log-format string    log output format
       --no-color            disable colored output
   -q, --quiet               disable progress updates
   -v, --verbose             enable verbose logging


### PR DESCRIPTION
`logformat` has been deprecated for a long time, and we are planning to drop it.